### PR TITLE
feat: implement edit subscription modal

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -40,3 +40,29 @@
 .read-the-docs {
   color: #888;
 }
+
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  margin-top: 1rem;
+}

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,12 +1,14 @@
 import { useState, useEffect } from 'react';
-import { deleteSubscription, getSubscriptions, updateSubscription, type Subscription } from './services/api';
+import { getSubscriptions, deleteSubscription, updateSubscription, type Subscription } from './services/api';
 import { SubscriptionForm } from './components/SubscriptionForm';
 import { SubscriptionList } from './components/SubscriptionList';
+import { EditModal } from './components/EditModal';
 import './App.css';
 
 // Componente principal da aplicação
 function App() {
-  const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
+  const [subscriptions, setSubscriptions] = useState<Subscription[]>([]); // Estado para armazenar a lista de assinaturas
+  const [editingSubscription, setEditingSubscription] = useState<Subscription | null>(null); // Estado para controlar a assinatura sendo editada
 
   // Função para buscar as assinaturas e atualizar o estado
   const fetchSubscriptions = async () => {
@@ -35,21 +37,13 @@ function App() {
   };
 
   // Função para atualizar uma assinatura
-  const handleUpdate = async (id: number) => {
-    const currentSub = subscriptions.find(sub => sub.id === id);
-    if (!currentSub) return;
-
-    // Simples prompt para editar o nome da assinatura
-    // Em uma aplicação real, usaríamos um modal ou um formulário dedicado
-    const newName = prompt("Enter new name:", currentSub.name);
-    if (newName && newName !== currentSub.name) {
-      try {
-        const updatedData = { ...currentSub, name: newName };
-        await updateSubscription(id, updatedData);
-        fetchSubscriptions();
-      } catch (error) {
-        console.error("Error updating subscription:", error);
-      }
+  const handleSaveEdit = async (updatedSub: Subscription) => {
+    try {
+      await updateSubscription(updatedSub.id, updatedSub);
+      setEditingSubscription(null); // Fecha o modal de edição
+      fetchSubscriptions(); // Recarrega a lista de assinaturas
+    } catch (error) {
+      console.error("Error updating subscription:", error);
     }
   };
 
@@ -64,9 +58,18 @@ function App() {
         <SubscriptionList
           subscriptions={subscriptions}
           onDelete={handleDelete}
-          onUpdate={handleUpdate}
+          onEdit={setEditingSubscription}
         />
       </div>
+
+      {/* Renderiza o modal de edição se houver uma assinatura sendo editada */}
+      {editingSubscription && (
+        <EditModal
+          subscription={editingSubscription}
+          onClose={() => setEditingSubscription(null)}
+          onSave={handleSaveEdit}
+        />
+      )}
     </>
   );
 }

--- a/client/src/components/EditModal.tsx
+++ b/client/src/components/EditModal.tsx
@@ -1,0 +1,68 @@
+import React, { useState, useEffect } from 'react';
+import { type Subscription } from '../services/api';
+
+interface EditModalProps {
+  subscription: Subscription; // Assinatura a ser editada
+  onClose: () => void; // Função para fechar o modal
+  onSave: (updatedSub: Subscription) => void; // Função para salvar as alterações
+}
+
+export const EditModal: React.FC<EditModalProps> = ({ subscription, onClose, onSave }) => {
+  // Estado interno para controlar os dados do formulário
+  const [formData, setFormData] = useState(subscription);
+
+  // Efeito para atualizar o formulário se a prop subscription mudar
+  useEffect(() => {
+    setFormData(subscription);
+  }, [subscription]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // Prepara os dados para salvar (convertendo o preço para número)
+    const dataToSave = {
+      ...formData,
+      price: parseFloat(formData.price.toString()),
+    };
+    onSave(dataToSave);
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal-content" onClick={(e) => e.stopPropagation()}>
+        <h2>Edit Subscription</h2>
+        <form onSubmit={handleSubmit}>
+          <label>Name:</label>
+          <input
+            type="text"
+            name="name"
+            value={formData.name}
+            onChange={handleChange}
+          />
+          <label>Price:</label>
+          <input
+            type="number"
+            name="price"
+            value={formData.price}
+            onChange={handleChange}
+          />
+          <label>Renewal Date:</label>
+          <input
+            type="date"
+            name="renewalDate"
+            value={new Date(formData.renewalDate).toISOString().split('T')[0]}
+            onChange={handleChange}
+          />
+          <div className="modal-actions">
+            <button type="submit">Save</button>
+            <button type="button" onClick={onClose}>Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/SubscriptionList.tsx
+++ b/client/src/components/SubscriptionList.tsx
@@ -5,25 +5,25 @@ import { type Subscription } from '../services/api';
 interface SubscriptionListProps {
   subscriptions: Subscription[]; // Lista de assinaturas a serem exibidas
   onDelete: (id: number) => void; // Callback para deletar uma assinatura
-  onUpdate: (id: number) => void; // Callback para atualizar uma assinatura
+  onEdit: (subscription: Subscription) => void; // Callback para editar uma assinatura
 }
 
 // Componente funcional que exibe a lista de assinaturas
-export const SubscriptionList: React.FC<SubscriptionListProps> = ({ subscriptions, onDelete, onUpdate }) => {
+export const SubscriptionList: React.FC<SubscriptionListProps> = ({ subscriptions, onDelete, onEdit }) => {
   return (
     <div>
       <h3>My Subscriptions</h3>
       <ul>
-      {subscriptions.map((sub) => {
-        // Mapear e exibir cada assinatura
-        return (
-          <li key={sub.id}>
-            <strong>{sub.name}</strong> - ${sub.price.toFixed(2)} - Renews on: {new Date(sub.renewalDate).toLocaleDateString()}
-            <button onClick={() => onUpdate(sub.id)}>Edit</button> {/* Botão para editar a assinatura */}
-            <button onClick={() => onDelete(sub.id)}>Delete</button> {/* Botão para deletar a assinatura */}
-          </li>
-        );
-      })}
+        {subscriptions.map((sub) => {
+          // Mapear e exibir cada assinatura
+          return (
+            <li key={sub.id}>
+              <strong>{sub.name}</strong> - ${sub.price.toFixed(2)} - Renews on: {new Date(sub.renewalDate).toLocaleDateString()}
+              <button onClick={() => onEdit(sub)} style={{ marginLeft: '10px'}}>Edit</button> {/* Botão para editar a assinatura */}
+              <button onClick={() => onDelete(sub.id)}>Delete</button> {/* Botão para deletar a assinatura */}
+            </li>
+          );
+        })}
       </ul>
     </div>
   );


### PR DESCRIPTION
This pull request introduces a modal-based editing experience for subscriptions, replacing the previous prompt-based approach. It adds a new `EditModal` component, updates the state management in the main `App` component, and applies new CSS styles for the modal. The changes improve the user experience and code maintainability.

**UI/UX Improvements:**

* Added a new `EditModal` component (`client/src/components/EditModal.tsx`) to provide a dedicated modal dialog for editing subscriptions, including form handling and validation.
* Updated the `SubscriptionList` component to trigger editing via the new modal, passing the full subscription object instead of just the ID. [[1]](diffhunk://#diff-f8d09da2eca251db6c54cc0d8791e37ef951f4896723ba5f47d7cb8669e8e09fL8-R12) [[2]](diffhunk://#diff-f8d09da2eca251db6c54cc0d8791e37ef951f4896723ba5f47d7cb8669e8e09fL22-R22)

**State Management and Logic:**

* Refactored the main `App` component to manage the editing state with `editingSubscription`, and replaced the previous prompt-based editing logic with modal-based editing. [[1]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337L2-R11) [[2]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337L38-L53) [[3]](diffhunk://#diff-ce931a2269184f4b06d6be36ead81f2ca3e95e44a5c8d600f47da1dfa35b9337L67-R72)

**Styling:**

* Added new CSS classes in `App.css` for modal overlay, content, and actions to style the edit modal dialog.