### PR TITLE
feat: add dashboard with total monthly cost

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,6 +3,7 @@ import { getSubscriptions, deleteSubscription, updateSubscription, type Subscrip
 import { SubscriptionForm } from './components/SubscriptionForm';
 import { SubscriptionList } from './components/SubscriptionList';
 import { EditModal } from './components/EditModal';
+import { Dashboard } from './components/Dashboard';
 import './App.css';
 
 // Componente principal da aplicação
@@ -60,6 +61,10 @@ function App() {
           onDelete={handleDelete}
           onEdit={setEditingSubscription}
         />
+      </div>
+      {/* Resumo das assinaturas */}
+      <div className="card">
+        <Dashboard subscriptions={subscriptions} />
       </div>
 
       {/* Renderiza o modal de edição se houver uma assinatura sendo editada */}

--- a/client/src/components/Dashboard.tsx
+++ b/client/src/components/Dashboard.tsx
@@ -1,0 +1,30 @@
+import React, { useMemo } from 'react';
+import { type Subscription } from '../services/api';
+
+interface DashboardProps {
+  subscriptions: Subscription[];
+}
+
+export const Dashboard: React.FC<DashboardProps> = ({ subscriptions }) => {
+  // Utilizando 'useMemo' para otimizar o cálculo (evita que o cálculo do total seja refeito em toda renderização, executando-o apenas quando a lista de assinaturas (subscriptions) for alterada)
+  const totalMonthlyCost = useMemo(() => {
+    const total = subscriptions.reduce((sum, sub) => sum + sub.price, 0);
+    return total;
+  }, [subscriptions]);
+
+  return (
+    <div>
+      <h3>Monthly Summary</h3>
+      <p>
+        <span>Total Cost: </span>
+        <strong>
+          {/* Formata o número para a moeda americana (US$) */}
+          {totalMonthlyCost.toLocaleString('en-US', {
+            style: 'currency',
+            currency: 'USD',
+          })}
+        </strong>
+      </p>
+    </div>
+  );
+};


### PR DESCRIPTION
This pull request introduces a new dashboard component to provide a summary of subscription costs and integrates it into the main application. The most important changes are:

**Feature Addition: Dashboard Component**

* Added a new `Dashboard` component in `client/src/components/Dashboard.tsx` that calculates and displays the total monthly cost of all subscriptions using `useMemo` for performance optimization.

**Integration into Application**

* Imported the new `Dashboard` component in `client/src/App.tsx`.
* Rendered the `Dashboard` component within the main application UI, passing the current list of subscriptions as a prop to display the monthly summary.