### PR TITLE
fix(ui): allow chart legend to wrap on multiple lines

### DIFF
--- a/client/src/App.css
+++ b/client/src/App.css
@@ -1,4 +1,3 @@
-/* Layout Principal */
 .container {
   max-width: 800px; /* Largura máxima do conteúdo */
   margin: 0 auto; /* Centraliza na página */
@@ -208,7 +207,7 @@ select {
   width: 100%;
   cursor: pointer;
 
-  /* Re-aplica os estilos que queremos (iguais aos do input) */
+  /* Estilos do Select */
   padding: 0.6em 1.2em;
   font-size: 1em;
   border-radius: 8px;
@@ -230,12 +229,13 @@ select {
 }
 
 .chart-container {
-  margin-top: 2rem; /* Este é o espaço que você queria! */
+  margin-top: 2rem;
 }
 
 .chart-legend {
   display: flex;
   justify-content: center;
+  flex-wrap: wrap; /* Permite que a legenda quebre em várias linhas se necessário */
   gap: 1.5rem;
   margin-bottom: 50px; /* Espaço entre a legenda e o gráfico */
 }
@@ -306,7 +306,6 @@ select {
   cursor: pointer;
   transition: background-color 0.25s; /* Transição mais suave */
 
-  /* Estilos que já tínhamos */
   width: 100%;
   margin-top: 0.5rem;
 


### PR DESCRIPTION
This pull request makes minor improvements to the CSS styling in `client/src/App.css`, focusing on code clarity and layout flexibility. The changes mainly update comments to better describe the styles and enhance the chart legend's responsiveness.

Layout and style improvements:

* Updated comments in the `select` styles to clarify the purpose of padding and other properties, making the code easier to understand and maintain. [[1]](diffhunk://#diff-32d1dced60f884eceee5905cccdf17256fe157a222e66e7863e8c5c6e9ea9cd4L211-R210) [[2]](diffhunk://#diff-32d1dced60f884eceee5905cccdf17256fe157a222e66e7863e8c5c6e9ea9cd4L309)
* Added `flex-wrap: wrap` to the `.chart-legend` class, allowing the legend to break into multiple lines for better responsiveness on smaller screens.
* Removed redundant comments and slightly cleaned up margin styling for better code readability. [[1]](diffhunk://#diff-32d1dced60f884eceee5905cccdf17256fe157a222e66e7863e8c5c6e9ea9cd4L1) [[2]](diffhunk://#diff-32d1dced60f884eceee5905cccdf17256fe157a222e66e7863e8c5c6e9ea9cd4L233-R238)